### PR TITLE
update Python example encoding command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Encoding (Win Git/WSL)
 
 Encoding (Python)
 
-`base64.b64encode(lzma.compress(bytes("hello world",encoding="utf-8"), format=lzma.FORMAT_ALONE, preset=9))`
+`'https://itty.bitty.site/#/'+base64.b64encode(lzma.compress(bytes("hello world",encoding="utf-8"), format=lzma.FORMAT_ALONE, preset=9)).decode("utf-8")`
 
 Encoding (Node.js)
 


### PR DESCRIPTION
to match the other example encodings including the whole URL not just the data fragment